### PR TITLE
Enable hardware acceleration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
     <application
         android:name="com.zfdang.SMTHApplication"
         android:allowBackup="true"
-        android:hardwareAccelerated="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         </activity>
         <activity
             android:name=".PostListActivity"
+            android:hardwareAccelerated="false"
             android:label="@string/title_topic_detail"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
@@ -66,6 +67,7 @@
         <!-- full screen activities -->
         <activity
             android:name=".FSImageViewerActivity"
+            android:hardwareAccelerated="false"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/title_activity_fullscreen_image_viewer"
             android:theme="@style/FullscreenTheme">


### PR DESCRIPTION
Since enabling it truly makes a difference, especially on high-end devices, any reason not to use it?